### PR TITLE
Lese inn application_stack og sette default_image_name

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -2,21 +2,21 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/azurerm" {
-  version     = "4.18.0"
+  version     = "4.26.0"
   constraints = ">= 4.18.0, < 5.0.0"
   hashes = [
-    "h1:mQij8+qbLiJTmv2eytyj5EgtlYuLVSydNfpf0bat74w=",
-    "zh:0e36f194b9c558a7ab25d300d126ddaab74cdeb077ebc143656ec6c8d8bafa11",
-    "zh:68f04ef1a13105766f92096168e1a3d8157625e2c4e11f32257a3818a790946f",
-    "zh:695a6400cfa851827ba3ba2d083391059bbf6cddae4723291ac085dc8a87d668",
-    "zh:88638f2600a33baf70bae435260d4dcb8e239fd80be44b7c7cfcb6e2bb51fda4",
-    "zh:983bfffcee94dc7b720132599fa7da39c1049d7fd2ef8bbdabb6cd60dbbb95e6",
-    "zh:ac296ca105da80fb17faed36ec38027a5d5a01545b60b31cd9f1f0ec8ea9e619",
-    "zh:c4efeac23ac3596b75ca3eddc82e167e1c6e26ad2c169d3d6fa57b46ea1d44bb",
-    "zh:d4bc05093d6a32e36e838c00a3baa2500bd025c8a52fb7b4d84a1f31690ed8e6",
-    "zh:da225d297000ff64452a765ebe4952741dc72bd4f742284f6a5470e4c6703235",
-    "zh:eba013ccf5d7efd687c7a4105d71499e0af42e4c64306c7364ddbab52499fcbd",
-    "zh:ebe939362204ebbcaadb6a88287f309060828de4c952cb5f9cfe58459078d0ee",
+    "h1:Vdylhj5W0M+J62bOOdvVUlmGB7M5TfaNRcThdb8ydcc=",
+    "zh:0e381bace81028596d60e253bc320bf62d00ae2ec207d7c7e70cdbec5f543334",
+    "zh:32c8cf70e476a4d0e0a2d4cb94b4a4e95c287c5972ca1e8c0f37dc629fbe31cb",
+    "zh:568ebaa4c66fc668dc14c8ff323e47fc7b2ac3b5a5d9eec612de2b6a30164f4c",
+    "zh:596c218810ffb85bc7224574b6ba6dbab9295bfa7490eac98c5ff88beae75710",
+    "zh:75a0e5b60f24684d62944714deb1c790b17c8d4acc93b5cdb45a8187d887b7f1",
+    "zh:7d2abea6ab66a08fed7d1ab8d4f3a8344fe7e2ac76d7409a3e40e8c066df6f22",
+    "zh:7f4db75991fd610b2c0306226e5e1916d4b633cdb0126bc78951dce2365b3418",
+    "zh:95fe307defb6e0dc172855fa597140f3da96655b3c558c140ae51a4a6077f58d",
+    "zh:ae07cdd3c658c0e24d45f1cfadf8b085b18981bcd72a20093ce3f042ed0adf3f",
+    "zh:d2a471b9e42499a7247f873aebd5cbc8df0c6691f02a5c9b556aa00045c06869",
+    "zh:e0299c0f6eae2b1c935f552f76fc49a2e61975eeda9410e3920a004b74d9e750",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }

--- a/main.tf
+++ b/main.tf
@@ -33,8 +33,8 @@ resource "azurerm_linux_web_app" "linux_web_app" {
     ip_restriction_default_action = try(var.configuration.ip_restriction_default_action, "Allow")
 
     application_stack {
-      docker_image_name        = try(var.configuration.site_config.application_stack.docker_image_name, null)
-      docker_registry_url      = try(var.configuration.site_config.application_stack.docker_registry_url, null)
+      docker_image_name        = try(var.configuration.site_config.application_stack.docker_image_name, "index.docker.io/nginx:mainline")
+      docker_registry_url      = try(var.configuration.site_config.application_stack.docker_registry_url, "https://index.docker.io")
       docker_registry_username = try(var.configuration.site_config.application_stack.docker_registry_username, null)
       docker_registry_password = try(var.configuration.site_config.application_stack.docker_registry_password, null)
       java_version             = try(var.configuration.site_config.application_stack.java_version, null)
@@ -87,7 +87,8 @@ resource "azurerm_linux_web_app" "linux_web_app" {
 
   lifecycle {
     ignore_changes = [
-      virtual_network_subnet_id
+      virtual_network_subnet_id,
+      site_config[0].application_stack[0].docker_image_name
     ]
   }
 

--- a/main.tf
+++ b/main.tf
@@ -26,11 +26,24 @@ resource "azurerm_linux_web_app" "linux_web_app" {
     container_registry_use_managed_identity       = try(var.configuration.site_config.container_registry_use_managed_identity, false)
 
     health_check_path                 = try(var.configuration.site_config.health_check_path, null)
-    health_check_eviction_time_in_min = try(var.configuration.site_config.health_check_eviction_time_in_min, null)
+    health_check_eviction_time_in_min = try(var.configuration.site_config.health_check_eviction_time_in_min, 2)
 
     vnet_route_all_enabled = try(var.configuration.site_config.vnet_route_all_enabled, false)
 
     ip_restriction_default_action = try(var.configuration.ip_restriction_default_action, "Allow")
+
+    application_stack {
+      docker_image_name        = try(var.configuration.site_config.application_stack.docker_image_name, null)
+      docker_registry_url      = try(var.configuration.site_config.application_stack.docker_registry_url, null)
+      docker_registry_username = try(var.configuration.site_config.application_stack.docker_registry_username, null)
+      docker_registry_password = try(var.configuration.site_config.application_stack.docker_registry_password, null)
+      java_version             = try(var.configuration.site_config.application_stack.java_version, null)
+      dotnet_version           = try(var.configuration.site_config.application_stack.dotnet_version, null)
+      python_version           = try(var.configuration.site_config.application_stack.python_version, null)
+      node_version             = try(var.configuration.site_config.application_stack.node_version, null)
+      go_version               = try(var.configuration.site_config.application_stack.go_version, null)
+      php_version              = try(var.configuration.site_config.application_stack.php_version, null)
+    }
 
     dynamic "ip_restriction" {
       for_each = try(var.configuration.ip_restriction, null) != null ? var.configuration.ip_restriction : []


### PR DESCRIPTION
Setter `default_image_name` hvis man ikke spesifiserer det, og legger `default_image_name` i `lifecycle.ignore_changes` slik at `default_image_name` ikke forvaltes av Terraform.